### PR TITLE
fixing bug where I wasn't referring to the cached key correctly, now …

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,16 +2,20 @@
 
 <https://github.com/reecemillsom/http-request-client>
 
+**Point to Note**
+
+This project uses XMLHttpRequest from the window, so as long as your projects have access to the DOM this will work.
+
 **Installation and Usage**
 
 1. npm i --save http-request-client
 2. import {get, post, put, del} from "http-request-client";
 
-Each request type has a handle request function. They have 3 params but only one is required.
+Each request type has a handleRequest function which returns a promise result or error. The function has 3 params but only one is required.
 
 Params are:
 
-1. Url type string *required. This is the url you want to do a request to.
+1. Url type string **required**. This is the url you want to do a request to.
 2. Headers type object. This is if you have headers you wish to set when doing a request.
 3. Data you wish to send. This is if you have data to send along with the request. Typically when using a put or post request. If your sending JSON, please stringify before passing as a param.
 
@@ -21,10 +25,16 @@ Example of how to pass headers:
 {"Content-type": "application/x-www-form-urlencoded"}
 ```
 
-Return value will be either a error result saying that the request was unsuccessful or successful, or in the case of Get request it may contain a JSON result.
+If you wish to see examples of how to use this module then look at the scripts directory:
 
-If you wish to see examples of how to use this then look at the scripts directory.
+<https://github.com/reecemillsom/http-request-client/tree/master/scripts>
+
+You can run these if you clone the project and do e.g. ```node scripts/filename.js``` assuming you are in root of project. Change the urls, use headers and become familiar with how to use it.
 
 **Cache**
 
-This module used a caching module to store previous get request results for 12 hours. In future I hope to expose this for users to choose how long they wish to store values in cache.
+This module uses a caching module to store previous get request results for 12 hours.
+
+**Issues**
+
+If you find an issue please feel free to contact me, or open an issue on the project and I will look into it as soon as I can.

--- a/dist/src/Request/GetRequest/GetRequest.js
+++ b/dist/src/Request/GetRequest/GetRequest.js
@@ -60,7 +60,7 @@ var GetRequest = (function (_super) {
                         if (!url) {
                             return [2, Bluebird.reject({ error: "Please provide a url" })];
                         }
-                        if (this.isValueInCache()) {
+                        if (this.isValueInCache(url)) {
                             return [2, Bluebird.resolve(this.cache.get(url))];
                         }
                         return [4, this.getResponse(url, headers, data)];
@@ -91,8 +91,8 @@ var GetRequest = (function (_super) {
             xmlHttpRequest.send();
         });
     };
-    GetRequest.prototype.isValueInCache = function () {
-        var cacheValue = this.cache.get("url");
+    GetRequest.prototype.isValueInCache = function (url) {
+        var cacheValue = this.cache.get(url);
         return !!cacheValue;
     };
     GetRequest.prototype.parseResponse = function (responseText) {

--- a/index.ts
+++ b/index.ts
@@ -6,7 +6,6 @@ import {PostRequest} from "./src/Request/PostRequest/PostRequest";
 import {PutRequest} from "./src/Request/PutRequest/PutRequest";
 import {XMLHttpRequestFactory} from "./src/XMLHttpRequestFactory/XMLHttpRequestFactory";
 
-
 const nodeCache = new NodeCache( { stdTTL: 43200, checkperiod: 300 }),
 	cache = new Cache(nodeCache),
 	factory = new XMLHttpRequestFactory(XMLHttpRequest),

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "http-request-client",
-  "version": "1.0.5",
+  "version": "1.0.6",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "http-request-client",
-  "version": "1.0.5",
+  "version": "1.0.6",
   "description": "Http Client wrapper for doing requests",
   "main": "./dist/index.js",
   "scripts": {

--- a/src/Request/GetRequest/GetRequest.ts
+++ b/src/Request/GetRequest/GetRequest.ts
@@ -11,7 +11,7 @@ export class GetRequest extends Request {
 
 		}
 
-		if (this.isValueInCache()) {
+		if (this.isValueInCache(url)) {
 
 			return Bluebird.resolve(this.cache.get(url));
 
@@ -65,9 +65,9 @@ export class GetRequest extends Request {
 	}
 
 
-	private isValueInCache() {
+	private isValueInCache(url: string) {
 
-		const cacheValue = this.cache.get("url");
+		const cacheValue = this.cache.get(url);
 
 		return !!cacheValue;
 


### PR DESCRIPTION
…this is fixed cached results from get requests can be served instead of doing a fresh request each time